### PR TITLE
Add scrabbleHand arb

### DIFF
--- a/src/commonMain/kotlin/io/kotest/property/arbs/games/scrabble.kt
+++ b/src/commonMain/kotlin/io/kotest/property/arbs/games/scrabble.kt
@@ -1,0 +1,35 @@
+package io.kotest.property.arbs.games
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+
+data class ScrabbleTile(val letter: Char, val points: Int) {
+  companion object {
+    val Blank = ScrabbleTile('_', 0)
+
+    private val distribution: List<Triple<Char, Int, Int>> = listOf(
+      Triple('A', 1, 9), Triple('B', 3, 2), Triple('C', 3, 2), Triple('D', 2, 4),
+      Triple('E', 1, 12), Triple('F', 4, 2), Triple('G', 2, 3), Triple('H', 4, 2),
+      Triple('I', 1, 9), Triple('J', 8, 1), Triple('K', 5, 1), Triple('L', 1, 4),
+      Triple('M', 3, 2), Triple('N', 1, 6), Triple('O', 1, 8), Triple('P', 3, 2),
+      Triple('Q', 10, 1), Triple('R', 1, 6), Triple('S', 1, 4), Triple('T', 1, 6),
+      Triple('U', 1, 4), Triple('V', 4, 2), Triple('W', 4, 2), Triple('X', 8, 1),
+      Triple('Y', 4, 2), Triple('Z', 10, 1),
+    )
+
+    val bag: List<ScrabbleTile> = buildList {
+      for ((letter, points, count) in distribution) {
+        repeat(count) { add(ScrabbleTile(letter, points)) }
+      }
+      repeat(2) { add(Blank) }
+    }
+  }
+}
+
+data class ScrabbleHand(val tiles: List<ScrabbleTile>) {
+  val score: Int = tiles.sumOf { it.points }
+}
+
+fun Arb.Companion.scrabbleHand() = arbitrary {
+  ScrabbleHand(ScrabbleTile.bag.shuffled(it.random).take(7))
+}

--- a/src/jvmTest/kotlin/io/kotest/property/arbs/games/ScrabbleHandTest.kt
+++ b/src/jvmTest/kotlin/io/kotest/property/arbs/games/ScrabbleHandTest.kt
@@ -1,0 +1,22 @@
+package io.kotest.property.arbs.games
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.checkAll
+
+class ScrabbleHandTest : FunSpec() {
+  init {
+    test("scrabbleHand has 7 tiles drawn from the standard bag") {
+      checkAll(50, Arb.scrabbleHand()) { hand ->
+        hand.tiles.size shouldBe 7
+        hand.tiles.all { it in ScrabbleTile.bag } shouldBe true
+        hand.score shouldBe hand.tiles.sumOf { it.points }
+      }
+    }
+
+    test("the standard bag contains 100 tiles") {
+      ScrabbleTile.bag.size shouldBe 100
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New `ScrabbleTile(letter, points)` with a `Blank` tile
- A `bag: List<ScrabbleTile>` containing the standard 100-tile English distribution (E×12, A/I×9, O×8, N/R/T×6, ..., Q/Z×10pt×1, blank×2)
- New `ScrabbleHand(tiles)` with a computed `score`
- New `Arb.scrabbleHand()` that deals 7 tiles drawn without replacement from the bag

## Test plan
- [x] `./gradlew :jvmTest --tests "io.kotest.property.arbs.games.ScrabbleHandTest"` passes locally; verifies hand size of 7, tiles are from the bag, score is the sum of points, and bag size is 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)